### PR TITLE
feat: adds the handle.tombstone configuration to the JDBC Sink Connector

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -158,6 +158,13 @@ Data Mapping
   * Default: ""
   * Importance: medium
 
+``handle.tombstone``
+  Controls whether tombstone (deletion) records in Kafka are processed by the connector. If set to `true`, tombstone records are skipped.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
 DDL Support
 ^^^^^^^^^^^
 

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -182,6 +182,8 @@ public class JdbcSinkConfig extends JdbcConfig {
     private static final String DATAMAPPING_GROUP = "Data Mapping";
     private static final String DDL_GROUP = "DDL Support";
     private static final String RETRIES_GROUP = "Retries";
+    public static final String HANDLE_TOMBSTONE_CONFIG = "handle.tombstone";
+    private static final String HANDLE_TOMBSTONE_DOC = "Skip tombstone records";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef();
 
@@ -354,7 +356,11 @@ public class JdbcSinkConfig extends JdbcConfig {
                 RETRIES_GROUP,
                 2,
                 ConfigDef.Width.SHORT,
-                RETRY_BACKOFF_MS_DISPLAY);
+                RETRY_BACKOFF_MS_DISPLAY)
+            .define(HANDLE_TOMBSTONE_CONFIG,
+                ConfigDef.Type.BOOLEAN, false,
+                ConfigDef.Importance.MEDIUM, HANDLE_TOMBSTONE_DOC);
+
     }
 
     public final String tableNameFormat;
@@ -370,6 +376,7 @@ public class JdbcSinkConfig extends JdbcConfig {
     public final List<String> pkFields;
     public final Set<String> fieldsWhitelist;
     public final TimeZone timeZone;
+    public final boolean handleTombstone;
 
     public JdbcSinkConfig(final Map<?, ?> props) {
         super(CONFIG_DEF, props);
@@ -387,6 +394,7 @@ public class JdbcSinkConfig extends JdbcConfig {
         fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
         final String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
         timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
+        handleTombstone = getBoolean(HANDLE_TOMBSTONE_CONFIG);
     }
 
     static Map<String, String> topicToTableMapping(final List<String> value) {


### PR DESCRIPTION
This PR adds the handle.tombstone configuration to the JDBC Sink Connector, allowing users to control how tombstone records (representing deletions in Kafka) are handled. When set to true, these null records are skipped.

#165