### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '42 20 * * 6'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
This should solve the permission errors we've seen in CodeQL. The original file was generated by github and didn't have any permission limits, so not sure if this will actually work. But in theory these are the permissions that CodeQL needs, so lets just try force them