### PR TITLE
Add support for Oracle network data encryption and integrity

### DIFF
--- a/docs/sink-connector.md
+++ b/docs/sink-connector.md
@@ -52,6 +52,10 @@ For example, for PostgreSQL the connection URL might look like
 jdbc:postgresql://localhost:5432/test?user=fred&password=secret&ssl=true
 ```
 
+For Oracle databases it's possible to configure [network data
+encryption and integrity](https://docs.oracle.com/cd/B19306_01/network.102/b14268/asojbdc.htm#g1007990)
+by setting `oracle.net.encryption_client` and `oracle.net.crypto_checksum_client`.
+
 ### SQL Dialects
 
 Different databases use different dialects of SQL. The connector

--- a/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
@@ -60,6 +60,20 @@ public class JdbcConfig extends AbstractConfig {
             + "specific dialect. All properly-packaged dialects in the JDBC connector plugin "
             + "can be used.";
 
+    public static final String ORACLE_ENCRYPTION_CLIENT_CONFIG = "oracle.net.encryption_client";
+    private static final String ORACLE_ENCRYPTION_CLIENT_DISPLAY = "Oracle encryption";
+    private static final String ORACLE_ENCRYPTION_CLIENT_DOC =
+        "This parameter defines the level of security that the client wants to negotiate with "
+            + "the server. The permitted values are \"REJECTED\", \"ACCEPTED\", \"REQUESTED\" and "
+            + "\"REQUIRED\"";
+
+    public static final String ORACLE_CHECKSUM_CLIENT_CONFIG = "oracle.net.crypto_checksum_client";
+    private static final String ORACLE_CHECKSUM_CLIENT_DISPLAY = "Oracle crypto checksum";
+    private static final String ORACLE_CHECKSUM_CLIENT_DOC =
+        "This parameter defines the level of security that the client wants to negotiate with "
+            + "the server for data integrity. The permitted values are \"REJECTED\", \"ACCEPTED\", "
+            + "\"REQUESTED\" and \"REQUIRED\"";
+
     public static final String SQL_QUOTE_IDENTIFIERS_CONFIG = "sql.quote.identifiers";
     private static final Boolean SQL_QUOTE_IDENTIFIERS_DEFAULT = true;
     private static final String SQL_QUOTE_IDENTIFIERS_DOC =
@@ -81,6 +95,14 @@ public class JdbcConfig extends AbstractConfig {
 
     public final String getConnectionUser() {
         return getString(CONNECTION_USER_CONFIG);
+    }
+
+    public final String getOracleEncryptionClient() {
+        return getString(JdbcConfig.ORACLE_ENCRYPTION_CLIENT_CONFIG);
+    }
+
+    public final String getOracleChecksumClient() {
+        return getString(JdbcConfig.ORACLE_CHECKSUM_CLIENT_CONFIG);
     }
 
     public final TimeZone getDBTimeZone() {
@@ -168,6 +190,36 @@ public class JdbcConfig extends AbstractConfig {
             ConfigDef.Width.MEDIUM,
             DIALECT_NAME_DISPLAY,
             DatabaseDialectRecommender.INSTANCE
+        );
+    }
+
+    protected static void defineOracleEncryptionClient(final ConfigDef configDef, final int orderInGroup) {
+        configDef.define(
+            JdbcConfig.ORACLE_ENCRYPTION_CLIENT_CONFIG,
+            ConfigDef.Type.STRING,
+            null,
+            null,
+            ConfigDef.Importance.LOW,
+            JdbcConfig.ORACLE_ENCRYPTION_CLIENT_DOC,
+            DATABASE_GROUP,
+            orderInGroup,
+            ConfigDef.Width.LONG,
+            JdbcConfig.ORACLE_ENCRYPTION_CLIENT_DISPLAY
+        );
+    }
+
+    protected static void defineOracleChecksumClient(final ConfigDef configDef, final int orderInGroup) {
+        configDef.define(
+            JdbcConfig.ORACLE_CHECKSUM_CLIENT_CONFIG,
+            ConfigDef.Type.STRING,
+            null,
+            null,
+            ConfigDef.Importance.LOW,
+            JdbcConfig.ORACLE_CHECKSUM_CLIENT_DOC,
+            DATABASE_GROUP,
+            orderInGroup,
+            ConfigDef.Width.LONG,
+            JdbcConfig.ORACLE_CHECKSUM_CLIENT_DISPLAY
         );
     }
 

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
@@ -36,6 +36,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.sink.JdbcSinkConfig;
 import io.aiven.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.aiven.connect.jdbc.sink.metadata.SchemaPair;
@@ -133,6 +134,8 @@ public interface DatabaseDialect extends ConnectionProvider {
      * @return the dialect's name; never null
      */
     String name();
+
+    public void setDialectSpecificProperties(final JdbcConfig config);
 
     /**
      * Create a new prepared statement using the specified database connection.

--- a/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -186,6 +186,12 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
 
     @Override
+    public void setDialectSpecificProperties(
+        final JdbcConfig config
+    ) {
+    }
+
+    @Override
     public String name() {
         return getClass().getSimpleName().replace("DatabaseDialect", "");
     }

--- a/src/main/java/io/aiven/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -216,4 +216,17 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
             .replaceAll("(:thin:[^/]*)/([^@]*)@", "$1/****@")
             .replaceAll("(:oci[^:]*:[^/]*)/([^@]*)@", "$1/****@");
     }
+
+    @Override
+    public void setDialectSpecificProperties(
+        final JdbcConfig config
+    ) {
+        if (config.getOracleEncryptionClient() != null) {
+            System.setProperty(JdbcConfig.ORACLE_ENCRYPTION_CLIENT_CONFIG, config.getOracleEncryptionClient());
+        }
+
+        if (config.getOracleChecksumClient() != null) {
+            System.setProperty(JdbcConfig.ORACLE_CHECKSUM_CLIENT_CONFIG, config.getOracleChecksumClient());
+        }
+    }
 }

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -194,6 +194,8 @@ public class JdbcSinkConfig extends JdbcConfig {
         defineDbTimezone(CONFIG_DEF, ++orderInGroup);
         defineDialectName(CONFIG_DEF, ++orderInGroup);
         defineSqlQuoteIdentifiers(CONFIG_DEF, ++orderInGroup);
+        defineOracleEncryptionClient(CONFIG_DEF, ++orderInGroup);
+        defineOracleChecksumClient(CONFIG_DEF, ++orderInGroup);
 
         // Writes
         CONFIG_DEF

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkTask.java
@@ -58,6 +58,7 @@ public class JdbcSinkTask extends SinkTask {
             final String connectionUrl = config.getConnectionUrl();
             dialect = DatabaseDialects.findBestFor(connectionUrl, config);
         }
+        dialect.setDialectSpecificProperties(config);
         final DbStructure dbStructure = new DbStructure(dialect);
         log.info("Initializing writer using SQL dialect: {}", dialect.getClass().getSimpleName());
         writer = new JdbcDbWriter(config, dialect, dbStructure);

--- a/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -22,9 +22,12 @@ import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigException;
 
+import io.aiven.connect.jdbc.config.JdbcConfig;
+
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
 
 public class JdbcSinkConfigTest {
@@ -71,4 +74,22 @@ public class JdbcSinkConfigTest {
         new JdbcSinkConfig(props);
     }
 
+    @Test
+    public void shouldParseOracleSpecificConfiguration() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(JdbcSinkConfig.CONNECTION_URL_CONFIG, "jdbc://localhost");
+
+        JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+        assertNull(config.getOracleEncryptionClient());
+        assertNull(config.getOracleChecksumClient());
+
+        props.put(JdbcConfig.ORACLE_ENCRYPTION_CLIENT_CONFIG, "REQUIRED");
+        props.put(JdbcConfig.ORACLE_CHECKSUM_CLIENT_CONFIG, "ACCEPTED");
+
+        config = new JdbcSinkConfig(props);
+
+        assertEquals(config.getOracleEncryptionClient(), "REQUIRED");
+        assertEquals(config.getOracleChecksumClient(), "ACCEPTED");
+    }
 }


### PR DESCRIPTION
This patchset adds the possibility of configuring network data encryption and integrity for Oracle sinks.