### PR TITLE
Implement Tombstone Message Handling for JDBC Sink Connector

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import java.io.FileOutputStream
 import java.net.URL
 
 /*
- * Copyright 2021 Aiven Oy and jdbc-connector-for-apache-kafka contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,6 +163,7 @@ dependencies {
 
     runtimeOnly("org.xerial:sqlite-jdbc:3.46.0.0")
     runtimeOnly("org.postgresql:postgresql:42.7.3")
+    runtimeOnly("com.oracle.database.jdbc:ojdbc8:23.4.0.24.05")
     runtimeOnly("net.sourceforge.jtds:jtds:1.3.1")
     runtimeOnly("net.snowflake:snowflake-jdbc:3.16.0")
     runtimeOnly("com.microsoft.sqlserver:mssql-jdbc:12.6.1.jre11")
@@ -201,6 +202,8 @@ dependencies {
     integrationTestImplementation("org.testcontainers:kafka:$testcontainersVersion") // this is not Kafka version
     integrationTestImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     integrationTestImplementation("org.testcontainers:postgresql:$testcontainersVersion")
+    integrationTestImplementation("org.testcontainers:oracle-free:$testcontainersVersion")
+
     integrationTestImplementation("org.awaitility:awaitility:$awaitilityVersion")
     integrationTestImplementation("org.assertj:assertj-db:2.0.2")
 

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -83,6 +83,25 @@ Writes
   * Valid Values: [0,...]
   * Importance: medium
 
+``delete.enabled``
+  Enable deletion of rows based on tombstone messages.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
+  Note:
+
+  A tombstone message has:
+
+  -   a not null key
+  -   a null value
+
+  In case of tombstone messages and ``delete.enabled`` set to ``true``,
+  the JDBC sink connector will delete the row referenced by the
+  message key. If set to ``true``, it requires the ``pk.mode`` to be
+  ``record_key`` to be able to identify the rows to delete.
+
 Data Mapping
 ^^^^^^^^^^^^
 

--- a/docs/sink-connector.md
+++ b/docs/sink-connector.md
@@ -182,6 +182,26 @@ the same.
 
 To use this mode, set `pk.mode=record_value`.
 
+## Deletion Handling
+
+### Tombstone Messages
+
+A tombstone message is a special type of record in Kafka that signifies
+the deletion of a key. It has:
+
+- a not null **key**
+- a null **value**
+
+Tombstone messages are typically used in compacted topics to indicate
+that the key should be removed from the downstream system.
+
+In case of tombstone messages and `delete.enabled` set to `true`,
+the JDBC sink connector will delete the row referenced by the
+message key. If set to `true`, it requires the `pk.mode` to be
+`record_key` to be able to identify the rows to delete.
+
+To enable deletion handling, set `delete.enabled=true`.
+
 ## Table Auto-Creation and Auto-Evolution
 
 ### Auto-Creation

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyDeleteIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyDeleteIT.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.jdbc.oracle;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import io.aiven.connect.jdbc.JdbcSinkConnector;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.assertj.db.type.Table;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class VerifyDeleteIT extends AbstractOracleIT {
+
+    private static final String TEST_TOPIC_NAME = "SINK_TOPIC";
+    private static final String CONNECTOR_NAME = "test-sink-connector";
+    private static final int TEST_TOPIC_PARTITIONS = 1;
+
+    private static final Schema VALUE_RECORD_SCHEMA = new Schema.Parser().parse("{\n"
+            + "  \"type\": \"record\",\n"
+            + "  \"name\": \"record\",\n"
+            + "  \"fields\": [\n"
+            + "    {\n"
+            + "      \"name\": \"name\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"value\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}");
+
+    private static final String CREATE_TABLE = String.format("CREATE TABLE \"%s\" (\n"
+            + "    \"id\" NUMBER NOT NULL,\n"
+            + "    \"name\" VARCHAR2(255) NOT NULL,\n"
+            + "    \"value\" VARCHAR2(255) NOT NULL,\n"
+            + "PRIMARY KEY(\"id\")"
+            + ")", TEST_TOPIC_NAME);
+
+    private Map<String, String> sinkConnectorConfigForDelete() {
+        final Map<String, String> config = basicConnectorConfig();
+        config.put("name", CONNECTOR_NAME);
+        config.put("connector.class", JdbcSinkConnector.class.getName());
+        config.put("topics", TEST_TOPIC_NAME);
+        config.put("pk.mode", "record_key");
+        config.put("pk.fields", "id"); // assigned name for the primitive key
+        config.put("delete.enabled", String.valueOf(true));
+        return config;
+    }
+
+    private ProducerRecord<String, GenericRecord> createRecord(
+            final int id, final int partition, final String name, final String value) {
+        final GenericRecord record = new GenericData.Record(VALUE_RECORD_SCHEMA);
+        record.put("name", name);
+        record.put("value", value);
+        return new ProducerRecord<>(TEST_TOPIC_NAME, partition, String.valueOf(id), record);
+    }
+
+    private ProducerRecord<String, GenericRecord> createTombstoneRecord(
+            final int id, final int partition) {
+        return new ProducerRecord<>(TEST_TOPIC_NAME, partition, String.valueOf(id), null);
+    }
+
+    private void sendTestData(final int numberOfRecords) throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String recordName = "user-" + i;
+                final String recordValue = "value-" + i;
+                final ProducerRecord<String, GenericRecord> msg = createRecord(i, partition, recordName, recordValue);
+                sendFutures.add(producer.send(msg));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    private void sendTestDataWithTombstone(final int numberOfRecords) throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final ProducerRecord<String, GenericRecord> record = createTombstoneRecord(i, partition);
+                sendFutures.add(producer.send(record));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    private void sendMixedTestDataWithTombstone(final int numberOfRecords, final int numberOfTombstoneRecords)
+            throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String recordName = "user-" + i;
+                final String recordValue = "value-" + i;
+                final ProducerRecord<String, GenericRecord> msg = createRecord(
+                        i, partition, recordName, recordValue);
+                sendFutures.add(producer.send(msg));
+                if (i < numberOfTombstoneRecords) {
+                    final ProducerRecord<String, GenericRecord> record = createTombstoneRecord(i, partition);
+                    sendFutures.add(producer.send(record));
+                }
+            }
+        }
+
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        executeSqlStatement(CREATE_TABLE);
+        createTopic(TEST_TOPIC_NAME, 1); // Create Kafka topic matching the table name
+    }
+
+    @Test
+    public void testDeleteTombstoneRecord() throws Exception {
+        // Test deleting records using tombstone records
+        connectRunner.createConnector(sinkConnectorConfigForDelete());
+        sendTestData(3);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2");
+                });
+
+        // Send test data to Kafka topic (including a tombstone record)
+        sendTestDataWithTombstone(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(2);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2");
+                });
+    }
+
+    @Test
+    public void testWithJustTombstoneRecordInInsertMode() throws Exception {
+        // Test behavior with only tombstone records in insert mode
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        connectRunner.createConnector(config);
+
+        sendTestDataWithTombstone(2);
+
+        // TODO: Instead of sleeping for a fixed interval,
+        //  wait for the connector to commit offsets for the records we sent
+        Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
+        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+    }
+
+    @Test
+    public void testDeleteTombstoneRecordWithMultiMode() throws Exception {
+        // Test deleting records using tombstone records with multi-insert mode enabled
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        config.put("insert.mode", "MULTI");
+        connectRunner.createConnector(config);
+
+        sendTestData(5);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+
+        sendTestDataWithTombstone(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(4);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+    }
+
+    @Test
+    public void testWithJustTombstoneRecordWithMultiMode() throws Exception {
+        // Test behavior with only tombstone records in multi-insert mode
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        config.put("insert.mode", "MULTI");
+        connectRunner.createConnector(config);
+
+        sendTestDataWithTombstone(2);
+
+        // TODO: Instead of sleeping for a fixed interval,
+        //  wait for the connector to commit offsets for the records we sent
+        Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
+        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+    }
+
+    @Test
+    public void testMixTombstoneRecordsWithMultiMode() throws Exception {
+        // Test behavior with mixed tombstone and insert records in multi-insert mode
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        config.put("insert.mode", "MULTI");
+        connectRunner.createConnector(config);
+
+        sendMixedTestDataWithTombstone(5, 2);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+    }
+}

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyInsertIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/oracle/VerifyInsertIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.jdbc.oracle;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import io.aiven.connect.jdbc.JdbcSinkConnector;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.assertj.db.type.Table;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class VerifyInsertIT extends AbstractOracleIT {
+
+    private static final String TEST_TOPIC_NAME = "SINK_TOPIC";
+    private static final String CONNECTOR_NAME = "test-sink-connector";
+    private static final int TEST_TOPIC_PARTITIONS = 1;
+    private static final Schema VALUE_RECORD_SCHEMA = new Schema.Parser().parse("{\n"
+            + "  \"type\": \"record\",\n"
+            + "  \"name\": \"record\",\n"
+            + "  \"fields\": [\n"
+            + "    {\n"
+            + "      \"name\": \"id\",\n"
+            + "      \"type\": \"int\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"name\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"value\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}");
+    private static final String CREATE_TABLE_WITH_PK = String.format("CREATE TABLE \"%s\" (\n"
+            + "    \"id\" NUMBER NOT NULL,\n"
+            + "    \"name\" VARCHAR2(255) NOT NULL,\n"
+            + "    \"value\" VARCHAR2(255) NOT NULL,\n"
+            + "PRIMARY KEY(\"id\")"
+            + ")", TEST_TOPIC_NAME);
+    private static final String CREATE_TABLE = String.format("CREATE TABLE \"%s\" (\n"
+            + "    \"id\" NUMBER NOT NULL,\n"
+            + "    \"name\" VARCHAR2(255) NOT NULL,\n"
+            + "    \"value\" VARCHAR2(255) NOT NULL\n"
+            + ")", TEST_TOPIC_NAME);
+
+
+    private Map<String, String> basicSinkConnectorConfig() {
+        final Map<String, String> config = basicConnectorConfig();
+        config.put("name", CONNECTOR_NAME);
+        config.put("connector.class", JdbcSinkConnector.class.getName());
+        config.put("topics", TEST_TOPIC_NAME);
+        return config;
+    }
+
+    private Map<String, String> sinkConnectorConfigWith_PKModeRecordKey() {
+        final Map<String, String> config = basicSinkConnectorConfig();
+        config.put("pk.mode", "record_key");
+        config.put("pk.fields", "id"); // assigned name for the primitive key
+        return config;
+    }
+
+    private Map<String, String> sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled() {
+        final Map<String, String> config = sinkConnectorConfigWith_PKModeRecordKey();
+        config.put("delete.enabled", String.valueOf(true));
+        return config;
+    }
+
+    private Map<String, String> sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled_InsertModeMulti() {
+        final Map<String, String> config = sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled();
+        config.put("insert.mode", "MULTI");
+        return config;
+    }
+
+    private ProducerRecord<String, GenericRecord> createRecord(
+            final int id, final int partition, final String name, final String value) {
+        final GenericRecord record = new GenericData.Record(VALUE_RECORD_SCHEMA);
+        record.put("id", id);
+        record.put("name", name);
+        record.put("value", value);
+        return new ProducerRecord<>(TEST_TOPIC_NAME, partition, String.valueOf(id), record);
+    }
+
+    private void sendTestData(final int numberOfRecords) throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String recordName = "user-" + i;
+                final String recordValue = "value-" + i;
+                final ProducerRecord<String, GenericRecord> msg = createRecord(i, partition, recordName, recordValue);
+                sendFutures.add(producer.send(msg));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        createTopic(TEST_TOPIC_NAME, 1); // Create Kafka topic matching the table name
+    }
+
+    @Test
+    public void testSinkConnector() throws Exception {
+        // Test basic sink connector functionality
+        executeSqlStatement(CREATE_TABLE);
+
+        // Start the sink connector
+        connectRunner.createConnector(basicSinkConnectorConfig());
+
+        // Send test data to Kafka topic
+        sendTestData(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0");
+                });
+    }
+
+    @Test
+    public void testSinkWithPKModeRecordKeyConnector() throws Exception {
+        // Test sink connector functionality with primary key mode set to record key
+        executeSqlStatement(CREATE_TABLE_WITH_PK);
+
+        // Start the sink connector
+        connectRunner.createConnector(sinkConnectorConfigWith_PKModeRecordKey());
+
+        // Send test data to Kafka topic
+        sendTestData(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0");
+                });
+    }
+
+    @Test
+    public void testSinkConnectorInDeleteMode() throws Exception {
+        // Test sink connector functionality with delete mode enabled
+        executeSqlStatement(CREATE_TABLE);
+
+        // Start the sink connector
+        connectRunner.createConnector(sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled());
+
+        // Send test data to Kafka topic
+        sendTestData(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0");
+                });
+    }
+
+    @Test
+    public void testMultiInsertInDeleteMode() throws Exception {
+        // Test multi-insert functionality in delete mode
+        executeSqlStatement(CREATE_TABLE);
+
+        // Start the sink connector
+        final Map<String, String> config = sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled_InsertModeMulti();
+        connectRunner.createConnector(config);
+
+        sendTestData(5);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+    }
+}

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/PartitionedTableIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/PartitionedTableIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class PartitionedTableIntegrationTest extends AbstractPostgresIT {
 
     @Test
     final void testBasicDelivery() throws ExecutionException, InterruptedException, SQLException {
-        executeUpdate(CREATE_TABLE);
+        executeSqlStatement(CREATE_TABLE);
         connectRunner.createConnector(basicSinkConnectorConfig());
 
         sendTestData(1000);
@@ -82,8 +82,8 @@ public class PartitionedTableIntegrationTest extends AbstractPostgresIT {
 
     @Test
     final void testBasicDeliveryForPartitionedTable() throws ExecutionException, InterruptedException, SQLException {
-        executeUpdate(CREATE_TABLE_WITH_PARTITION);
-        executeUpdate(CREATE_PARTITION);
+        executeSqlStatement(CREATE_TABLE_WITH_PARTITION);
+        executeSqlStatement(CREATE_PARTITION);
         connectRunner.createConnector(basicSinkConnectorConfig());
 
         sendTestData(1000);

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,10 +69,10 @@ public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
         // Make sure that the topic starts empty
         assertEmptyPoll(Duration.ofSeconds(1));
 
-        executeUpdate(createSchema(PREFERRED_SCHEMA));
-        executeUpdate(setSearchPath(postgreSqlContainer.getDatabaseName()));
-        executeUpdate(CREATE_PREFERRED_TABLE);
-        executeUpdate(POPULATE_PREFERRED_TABLE);
+        executeSqlStatement(createSchema(PREFERRED_SCHEMA));
+        executeSqlStatement(setSearchPath(postgreSqlContainer.getDatabaseName()));
+        executeSqlStatement(CREATE_PREFERRED_TABLE);
+        executeSqlStatement(POPULATE_PREFERRED_TABLE);
         connectRunner.createConnector(basicTimestampModeSourceConnectorConfig());
 
         await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(100))
@@ -107,19 +107,19 @@ public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
         // Make sure that the topic starts empty
         assertEmptyPoll(Duration.ofSeconds(1));
 
-        executeUpdate(createSchema(PREFERRED_SCHEMA));
-        executeUpdate(createSchema(OTHER_SCHEMA));
-        executeUpdate(setSearchPath(postgreSqlContainer.getDatabaseName()));
-        executeUpdate(CREATE_PREFERRED_TABLE);
-        executeUpdate(POPULATE_PREFERRED_TABLE);
-        executeUpdate(CREATE_OTHER_TABLE);
-        executeUpdate(POPULATE_OTHER_TABLE);
+        executeSqlStatement(createSchema(PREFERRED_SCHEMA));
+        executeSqlStatement(createSchema(OTHER_SCHEMA));
+        executeSqlStatement(setSearchPath(postgreSqlContainer.getDatabaseName()));
+        executeSqlStatement(CREATE_PREFERRED_TABLE);
+        executeSqlStatement(POPULATE_PREFERRED_TABLE);
+        executeSqlStatement(CREATE_OTHER_TABLE);
+        executeSqlStatement(POPULATE_OTHER_TABLE);
         connectRunner.createConnector(connectorConfig);
 
         await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
                 .until(this::assertSingleNewRecordProduced);
 
-        executeUpdate(POPULATE_OTHER_TABLE);
+        executeSqlStatement(POPULATE_OTHER_TABLE);
 
         // Make sure that, even after adding another row to the other table, the connector
         // doesn't publish any new records
@@ -127,7 +127,7 @@ public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
 
         // Add one more row to the preferred table, and verify that the connector
         // is able to read it
-        executeUpdate(POPULATE_PREFERRED_TABLE);
+        executeSqlStatement(POPULATE_PREFERRED_TABLE);
         await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
                 .until(this::assertSingleNewRecordProduced);
 
@@ -136,7 +136,7 @@ public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
 
         // Add one more row to the preferred table, and verify that the connector
         // is able to read it
-        executeUpdate(POPULATE_PREFERRED_TABLE);
+        executeSqlStatement(POPULATE_PREFERRED_TABLE);
         await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
                 .until(this::assertSingleNewRecordProduced);
 

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyDeleteIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyDeleteIT.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.jdbc.postgres;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import io.aiven.connect.jdbc.JdbcSinkConnector;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.assertj.db.type.Table;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class VerifyDeleteIT extends AbstractPostgresIT {
+
+    private static final String TEST_TOPIC_NAME = "sink_topic";
+    private static final String CONNECTOR_NAME = "test-sink-connector";
+    private static final int TEST_TOPIC_PARTITIONS = 1;
+
+    private static final Schema VALUE_RECORD_SCHEMA = new Schema.Parser().parse("{\n"
+            + "  \"type\": \"record\",\n"
+            + "  \"name\": \"record\",\n"
+            + "  \"fields\": [\n"
+            + "    {\n"
+            + "      \"name\": \"name\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"value\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}");
+
+    private static final String CREATE_TABLE = String.format("CREATE TABLE \"%s\" (\n"
+            + "    \"id\" VARCHAR(30) NOT NULL,\n"
+            + "    \"name\" VARCHAR(255) NOT NULL,\n"
+            + "    \"value\" VARCHAR(255) NOT NULL,\n"
+            + "PRIMARY KEY(\"id\")"
+            + ")", TEST_TOPIC_NAME);
+
+    private Map<String, String> sinkConnectorConfigForDelete() {
+        final Map<String, String> config = basicConnectorConfig();
+        config.put("name", CONNECTOR_NAME);
+        config.put("connector.class", JdbcSinkConnector.class.getName());
+        config.put("topics", TEST_TOPIC_NAME);
+        config.put("pk.mode", "record_key");
+        config.put("pk.fields", "id"); // assigned name for the primitive key
+        config.put("delete.enabled", String.valueOf(true));
+        return config;
+    }
+
+    private ProducerRecord<String, GenericRecord> createRecord(
+            final int id, final int partition, final String name, final String value) {
+        final GenericRecord record = new GenericData.Record(VALUE_RECORD_SCHEMA);
+        record.put("name", name);
+        record.put("value", value);
+        return new ProducerRecord<>(TEST_TOPIC_NAME, partition, String.valueOf(id), record);
+    }
+
+    private ProducerRecord<String, GenericRecord> createTombstoneRecord(
+            final int id, final int partition) {
+        return new ProducerRecord<>(TEST_TOPIC_NAME, partition, String.valueOf(id), null);
+    }
+
+    private void sendTestData(final int numberOfRecords) throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String recordName = "user-" + i;
+                final String recordValue = "value-" + i;
+                final ProducerRecord<String, GenericRecord> msg = createRecord(i, partition, recordName, recordValue);
+                sendFutures.add(producer.send(msg));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    private void sendTestDataWithTombstone(final int numberOfRecords) throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final ProducerRecord<String, GenericRecord> record = createTombstoneRecord(i, partition);
+                sendFutures.add(producer.send(record));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    private void sendMixedTestDataWithTombstone(final int numberOfRecords, final int numberOfTombstoneRecords)
+            throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String recordName = "user-" + i;
+                final String recordValue = "value-" + i;
+                final ProducerRecord<String, GenericRecord> msg = createRecord(
+                        i, partition, recordName, recordValue);
+                sendFutures.add(producer.send(msg));
+                if (i < numberOfTombstoneRecords) {
+                    final ProducerRecord<String, GenericRecord> record = createTombstoneRecord(i, partition);
+                    sendFutures.add(producer.send(record));
+                }
+            }
+        }
+
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        executeSqlStatement(CREATE_TABLE);
+        createTopic(TEST_TOPIC_NAME, 1); // Create Kafka topic matching the table name
+    }
+
+    @Test
+    public void testDeleteTombstoneRecord() throws Exception {
+        // Test deleting records using tombstone records
+        connectRunner.createConnector(sinkConnectorConfigForDelete());
+        sendTestData(3);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2");
+                });
+
+        // Send test data to Kafka topic (including a tombstone record)
+        sendTestDataWithTombstone(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(2);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2");
+                });
+    }
+
+    @Test
+    public void testWithJustTombstoneRecordInInsertMode() throws Exception {
+        // Test behavior with only tombstone records in insert mode
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        connectRunner.createConnector(config);
+
+        sendTestDataWithTombstone(2);
+
+        // TODO: Instead of sleeping for a fixed interval,
+        //  wait for the connector to commit offsets for the records we sent
+        Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
+        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+    }
+
+    @Test
+    public void testDeleteTombstoneRecordWithMultiMode() throws Exception {
+        // Test deleting records using tombstone records with multi-insert mode enabled
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        config.put("insert.mode", "MULTI");
+        connectRunner.createConnector(config);
+
+        sendTestData(5);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+
+        sendTestDataWithTombstone(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(4);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+    }
+
+    @Test
+    public void testWithJustTombstoneRecordWithMultiMode() throws Exception {
+        // Test behavior with only tombstone records in multi-insert mode
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        config.put("insert.mode", "MULTI");
+        connectRunner.createConnector(config);
+
+        sendTestDataWithTombstone(2);
+
+        // TODO: Instead of sleeping for a fixed interval,
+        //  wait for the connector to commit offsets for the records we sent
+        Thread.sleep(5_000); // Give the connector at least five seconds to read our tombstone messages from Kafka
+        assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(0);
+    }
+
+    @Test
+    public void testMixTombstoneRecordsWithMultiMode() throws Exception {
+        // Test behavior with mixed tombstone and insert records in multi-insert mode
+
+        final Map<String, String> config = sinkConnectorConfigForDelete();
+        config.put("insert.mode", "MULTI");
+        connectRunner.createConnector(config);
+
+        sendMixedTestDataWithTombstone(5, 2);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(3);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+    }
+}

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyInsertIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/VerifyInsertIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.jdbc.postgres;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import io.aiven.connect.jdbc.JdbcSinkConnector;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.assertj.db.type.Table;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class VerifyInsertIT extends AbstractPostgresIT {
+
+    private static final String TEST_TOPIC_NAME = "sink_topic";
+    private static final String CONNECTOR_NAME = "test-sink-connector";
+    private static final int TEST_TOPIC_PARTITIONS = 1;
+    private static final Schema VALUE_RECORD_SCHEMA = new Schema.Parser().parse("{\n"
+            + "  \"type\": \"record\",\n"
+            + "  \"name\": \"record\",\n"
+            + "  \"fields\": [\n"
+            + "    {\n"
+            + "      \"name\": \"id\",\n"
+            + "      \"type\": \"int\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"name\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"value\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}");
+    private static final String CREATE_TABLE_WITH_PK = String.format("CREATE TABLE \"%s\" (\n"
+            + "    \"id\" VARCHAR(30) NOT NULL PRIMARY KEY,\n"
+            + "    \"name\" VARCHAR(255) NOT NULL,\n"
+            + "    \"value\" VARCHAR(255) NOT NULL\n"
+            + ")", TEST_TOPIC_NAME);
+    private static final String CREATE_TABLE = String.format("CREATE TABLE \"%s\" (\n"
+            + "    \"id\" VARCHAR(30) NOT NULL,\n"
+            + "    \"name\" VARCHAR(255) NOT NULL,\n"
+            + "    \"value\" VARCHAR(255) NOT NULL\n"
+            + ")", TEST_TOPIC_NAME);
+
+
+    private Map<String, String> basicSinkConnectorConfig() {
+        final Map<String, String> config = basicConnectorConfig();
+        config.put("name", CONNECTOR_NAME);
+        config.put("connector.class", JdbcSinkConnector.class.getName());
+        config.put("topics", TEST_TOPIC_NAME);
+        return config;
+    }
+
+    private Map<String, String> sinkConnectorConfigWith_PKModeRecordKey() {
+        final Map<String, String> config = basicSinkConnectorConfig();
+        config.put("pk.mode", "record_key");
+        config.put("pk.fields", "id"); // assigned name for the primitive key
+        return config;
+    }
+
+    private Map<String, String> sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled() {
+        final Map<String, String> config = sinkConnectorConfigWith_PKModeRecordKey();
+        config.put("delete.enabled", String.valueOf(true));
+        return config;
+    }
+
+    private Map<String, String> sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled_InsertModeMulti() {
+        final Map<String, String> config = sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled();
+        config.put("insert.mode", "MULTI");
+        return config;
+    }
+
+    private ProducerRecord<String, GenericRecord> createRecord(
+            final int id, final int partition, final String name, final String value) {
+        final GenericRecord record = new GenericData.Record(VALUE_RECORD_SCHEMA);
+        record.put("id", id);
+        record.put("name", name);
+        record.put("value", value);
+        return new ProducerRecord<>(TEST_TOPIC_NAME, partition, String.valueOf(id), record);
+    }
+
+    private void sendTestData(final int numberOfRecords) throws InterruptedException, ExecutionException {
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String recordName = "user-" + i;
+                final String recordValue = "value-" + i;
+                final ProducerRecord<String, GenericRecord> msg = createRecord(i, partition, recordName, recordValue);
+                sendFutures.add(producer.send(msg));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        createTopic(TEST_TOPIC_NAME, 1); // Create Kafka topic matching the table name
+    }
+
+    @Test
+    public void testSinkConnector() throws Exception {
+        // Test basic sink connector functionality
+        executeSqlStatement(CREATE_TABLE);
+
+        // Start the sink connector
+        connectRunner.createConnector(basicSinkConnectorConfig());
+
+        // Send test data to Kafka topic
+        sendTestData(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0");
+                });
+    }
+
+    @Test
+    public void testSinkWithPKModeRecordKeyConnector() throws Exception {
+        // Test sink connector functionality with primary key mode set to record key
+        executeSqlStatement(CREATE_TABLE_WITH_PK);
+
+        // Start the sink connector
+        connectRunner.createConnector(sinkConnectorConfigWith_PKModeRecordKey());
+
+        // Send test data to Kafka topic
+        sendTestData(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0");
+                });
+    }
+
+    @Test
+    public void testSinkConnectorInDeleteMode() throws Exception {
+        // Test sink connector functionality with delete mode enabled
+        executeSqlStatement(CREATE_TABLE);
+
+        // Start the sink connector
+        connectRunner.createConnector(sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled());
+
+        // Send test data to Kafka topic
+        sendTestData(1);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(1);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0");
+                });
+    }
+
+    @Test
+    public void testMultiInsertInDeleteMode() throws Exception {
+        // Test multi-insert functionality in delete mode
+        executeSqlStatement(CREATE_TABLE);
+
+        // Start the sink connector
+        final Map<String, String> config = sinkConnectorConfigWith_PKModeRecordKey_DeleteEnabled_InsertModeMulti();
+        connectRunner.createConnector(config);
+
+        sendTestData(5);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).hasNumberOfRows(5);
+                    assertThat(new Table(getDatasource(), TEST_TOPIC_NAME)).column("ID")
+                            .value().isEqualTo("0")
+                            .value().isEqualTo("1")
+                            .value().isEqualTo("2")
+                            .value().isEqualTo("3")
+                            .value().isEqualTo("4");
+                });
+    }
+}

--- a/src/main/java/io/aiven/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/aiven/connect/jdbc/JdbcSinkConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,10 @@ public final class JdbcSinkConnector extends SinkConnector {
     @Override
     public Config validate(final Map<String, String> connectorConfigs) {
         // TODO cross-fields validation here: pkFields against the pkMode
-        return super.validate(connectorConfigs);
+        final Config config = super.validate(connectorConfigs);
+
+        JdbcSinkConfig.validateDeleteEnabled(config);
+        return config;
     }
 
     @Override

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -361,6 +361,21 @@ public interface DatabaseDialect extends ConnectionProvider {
     }
 
     /**
+     * Build the DELETE prepared statement expression for the given table and its columns.
+     *
+     * @param table      the identifier of the table; may not be null
+     * @param keyColumns the identifiers of the columns in the primary/unique key; may not be null
+     *                   but may be empty
+     * @return the DELETE statement; may not be null
+     * @throws UnsupportedOperationException if the dialect does not support delete
+     */
+    default String buildDeleteStatement(TableId table,
+                                        int records,
+                                        Collection<ColumnId> keyColumns) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Build the UPDATE prepared statement expression for the given table and its columns. Variables
      * for each key column should also appear in the WHERE clause of the statement.
      *
@@ -524,6 +539,17 @@ public interface DatabaseDialect extends ConnectionProvider {
          * @throws SQLException if there is a problem binding values into the statement
          */
         int bindRecord(int index, SinkRecord record) throws SQLException;
+
+        /**
+         * Bind the values in the supplied tombstone record.
+         *
+         * @param record the sink record with values to be bound into the statement; never null
+         * @throws SQLException if there is a problem binding values into the statement
+         * @throws UnsupportedOperationException if binding values is not supported
+         */
+        default void bindTombstoneRecord(SinkRecord record) throws SQLException, UnsupportedOperationException {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /**

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,13 +29,19 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
 
 import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.util.StringUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class JdbcSinkConfig extends JdbcConfig {
+    private static final Logger log = LoggerFactory.getLogger(JdbcSinkConfig.class);
 
     public enum InsertMode {
         INSERT,
@@ -176,6 +182,12 @@ public class JdbcSinkConfig extends JdbcConfig {
             + " while this configuration is applicable for the other columns.";
     private static final String FIELDS_WHITELIST_DISPLAY = "Fields Whitelist";
 
+    public static final String DELETE_ENABLED = "delete.enabled";
+    private static final String DELETE_ENABLED_DEFAULT = "false";
+    private static final String DELETE_ENABLED_DOC =
+            "Whether to enable the deletion of rows in the target table on tombstone messages";
+    private static final String DELETE_ENABLED_DISPLAY = "Delete enabled";
+
     private static final ConfigDef.Range NON_NEGATIVE_INT_VALIDATOR = ConfigDef.Range.atLeast(0);
 
     private static final String WRITES_GROUP = "Writes";
@@ -218,7 +230,20 @@ public class JdbcSinkConfig extends JdbcConfig {
                 BATCH_SIZE_DOC, WRITES_GROUP,
                 2,
                 ConfigDef.Width.SHORT,
-                BATCH_SIZE_DISPLAY);
+                BATCH_SIZE_DISPLAY)
+            .define(
+                // Delete can only be enabled with delete.enabled=true,
+                // but only when the pk.mode is set to record_key.
+                // This is because deleting a row from the table
+                // requires the primary key be used as criteria.
+                DELETE_ENABLED,
+                ConfigDef.Type.BOOLEAN,
+                DELETE_ENABLED_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                DELETE_ENABLED_DOC, WRITES_GROUP,
+                3,
+                ConfigDef.Width.SHORT,
+                DELETE_ENABLED_DISPLAY);
 
         // Data Mapping
         CONFIG_DEF
@@ -370,6 +395,7 @@ public class JdbcSinkConfig extends JdbcConfig {
     public final List<String> pkFields;
     public final Set<String> fieldsWhitelist;
     public final TimeZone timeZone;
+    public final boolean deleteEnabled;
 
     public JdbcSinkConfig(final Map<?, ?> props) {
         super(CONFIG_DEF, props);
@@ -387,6 +413,7 @@ public class JdbcSinkConfig extends JdbcConfig {
         fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
         final String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
         timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
+        deleteEnabled = getBoolean(DELETE_ENABLED);
     }
 
     static Map<String, String> topicToTableMapping(final List<String> value) {
@@ -436,5 +463,23 @@ public class JdbcSinkConfig extends JdbcConfig {
         System.out.println("=========================================");
         System.out.println();
         System.out.println(CONFIG_DEF.toEnrichedRst());
+    }
+
+    public static void validateDeleteEnabled(final Config config) {
+        // Collect all configuration values
+        final Map<String, ConfigValue> configValues = config.configValues().stream()
+                .collect(Collectors.toMap(ConfigValue::name, v -> v));
+
+        // Check if DELETE_ENABLED is true
+        final ConfigValue deleteEnabledConfigValue = configValues.get(JdbcSinkConfig.DELETE_ENABLED);
+        final boolean deleteEnabled = (boolean) deleteEnabledConfigValue.value();
+
+        // Check if PK_MODE is RECORD_KEY
+        final ConfigValue pkModeConfigValue = configValues.get(JdbcSinkConfig.PK_MODE);
+        final String pkMode = (String) pkModeConfigValue.value();
+
+        if (deleteEnabled && !JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY.name().equalsIgnoreCase(pkMode)) {
+            deleteEnabledConfigValue.addErrorMessage("Delete support only works with pk.mode=record_key");
+        }
     }
 }

--- a/src/main/java/io/aiven/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/PreparedStatementBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,6 +95,11 @@ public class PreparedStatementBinder implements StatementBinder {
             statement.addBatch();
         }
         return nextIndex;
+    }
+
+    public void bindTombstoneRecord(final SinkRecord record) throws SQLException {
+        bindKeyFields(record, 1);
+        statement.addBatch();
     }
 
     protected int bindKeyFields(final SinkRecord record, int index) throws SQLException {

--- a/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JdbcSinkConfigTest {
 
@@ -74,4 +76,17 @@ public class JdbcSinkConfigTest {
             .isInstanceOf(ConfigException.class);
     }
 
+    @Test
+    public void verifyDeleteEnabled() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(JdbcSinkConfig.CONNECTION_URL_CONFIG, "jdbc://localhost");
+        props.put(JdbcSinkConfig.DELETE_ENABLED, "true");
+        props.put(JdbcSinkConfig.PK_MODE, "record_key");
+        JdbcSinkConfig config = new JdbcSinkConfig(props);
+        assertTrue(config.deleteEnabled);
+
+        props.remove(JdbcSinkConfig.DELETE_ENABLED);
+        config = new JdbcSinkConfig(props);
+        assertFalse(config.deleteEnabled);
+    }
 }

--- a/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/JdbcSinkConnectorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.jdbc.sink;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
+
+import io.aiven.connect.jdbc.JdbcSinkConnector;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JdbcSinkConnectorTest {
+
+    private JdbcSinkConnector connector;
+
+    @BeforeEach
+    public void setUp() {
+        connector = new JdbcSinkConnector();
+    }
+
+    @Test
+    public void testValidate_withDeleteEnabledAndPkModeNotRecordKey_shouldAddErrorMessage() {
+        final Map<String, String> connectorConfigs = new HashMap<>();
+        connectorConfigs.put(JdbcSinkConfig.DELETE_ENABLED, "true");
+        connectorConfigs.put(JdbcSinkConfig.PK_MODE, "not_record_key");
+
+        final Config validatedConfig = connector.validate(connectorConfigs);
+
+        final Optional<ConfigValue> deleteEnabledConfigValue = validatedConfig.configValues().stream()
+                .filter(cv -> cv.name().equals(JdbcSinkConfig.DELETE_ENABLED))
+                .findFirst();
+
+        assertTrue(deleteEnabledConfigValue.isPresent());
+        deleteEnabledConfigValue.ifPresent(value ->
+                assertTrue(value.errorMessages().contains("Delete support only works with pk.mode=record_key"))
+        );
+    }
+
+    @Test
+    public void testValidate_withDeleteEnabledAndPkModeRecordKey_shouldNotAddErrorMessage() {
+        final Map<String, String> connectorConfigs = new HashMap<>();
+        connectorConfigs.put(JdbcSinkConfig.DELETE_ENABLED, "true");
+        connectorConfigs.put(JdbcSinkConfig.PK_MODE, "record_key");
+
+        final Config validatedConfig = connector.validate(connectorConfigs);
+
+        final Optional<ConfigValue> deleteEnabledConfigValue = validatedConfig.configValues().stream()
+                .filter(cv -> cv.name().equals(JdbcSinkConfig.DELETE_ENABLED))
+                .findFirst();
+
+        assertTrue(deleteEnabledConfigValue.isPresent());
+        deleteEnabledConfigValue.ifPresent(value ->
+                assertFalse(value.errorMessages().contains("Delete support only works with pk.mode=record_key"))
+        );
+    }
+
+    @Test
+    public void testValidate_pkModeRecordKey_shouldNotAddErrorMessage() {
+        final Map<String, String> connectorConfigs = new HashMap<>();
+        connectorConfigs.put(JdbcSinkConfig.PK_MODE, "record_key");
+
+        final Config validatedConfig = connector.validate(connectorConfigs);
+
+        final Optional<ConfigValue> deleteEnabledConfigValue = validatedConfig.configValues().stream()
+                .filter(cv -> cv.name().equals(JdbcSinkConfig.DELETE_ENABLED))
+                .findFirst();
+
+        assertTrue(deleteEnabledConfigValue.isPresent());
+        deleteEnabledConfigValue.ifPresent(value ->
+                assertFalse(value.errorMessages().contains("Delete support only works with pk.mode=record_key"))
+        );
+    }
+
+    @Test
+    public void testValidate_withDeleteDisabled_shouldNotAddErrorMessage() {
+        final Map<String, String> connectorConfigs = new HashMap<>();
+        connectorConfigs.put(JdbcSinkConfig.DELETE_ENABLED, "false");
+        connectorConfigs.put(JdbcSinkConfig.PK_MODE, "anything");
+
+        final Config validatedConfig = connector.validate(connectorConfigs);
+
+        final Optional<ConfigValue> deleteEnabledConfigValue = validatedConfig.configValues().stream()
+                .filter(cv -> cv.name().equals(JdbcSinkConfig.DELETE_ENABLED))
+                .findFirst();
+
+        assertTrue(deleteEnabledConfigValue.isPresent());
+        deleteEnabledConfigValue.ifPresent(value ->
+                assertTrue(value.errorMessages().isEmpty())
+        );
+
+    }
+}


### PR DESCRIPTION
## Description:

This pull request addresses issue #165, focusing on enhancing the functionality of the JDBC sink connector to handle deletes on tombstone messages effectively. By implementing this feature, users can now delete rows corresponding to tombstone messages, which is particularly useful for scenarios involving Change Data Capture (CDC) from another database.

#### Changes:

- Added support for handling tombstone messages in the JDBC sink connector.
- Implemented the ability to delete rows based on tombstone messages.
- Introduced a new parameter, `delete.enabled`, to control delete behavior.
- Aligned functionality with the documented approach for processing tombstones, similar to Confluent JDBC driver behavior.

**Related Issue(s):**
- Fixes #165


Signed-off-by: Joel Hanson <joelhanson025@gmail.com>