### PR TITLE
fix: integration tests to use timestamps with timezone

### DIFF
--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/PartitionedTableIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/PartitionedTableIntegrationTest.java
@@ -62,7 +62,7 @@ public class PartitionedTableIntegrationTest extends AbstractPostgresIT {
             + "(\n"
             + "    name  text      not null,\n"
             + "    value text      not null,\n"
-            + "    date  timestamp not null default '2022-03-04'\n"
+            + "    date  timestamp with time zone not null default '2022-03-04'\n"
             + ")";
     private static final String CREATE_TABLE_WITH_PARTITION = CREATE_TABLE + " partition by RANGE (date)";
     private static final String CREATE_PARTITION =

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
@@ -48,7 +48,7 @@ public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
                     + "    id int          generated always as identity primary key,\n"
                     + "    name  text      not null,\n"
                     + "    value text      not null,\n"
-                    + "    date  timestamp not null default current_timestamp\n"
+                    + "    date  timestamp with time zone not null default current_timestamp\n"
                     + ")";
     private static final String POPULATE_PREFERRED_TABLE =
             "insert into " + PREFERRED_SCHEMA + "." + TABLE + " (name, value) values\n"


### PR DESCRIPTION
The integration tests failed on local environment when timezone was other than UTC. Use timezone aware timestamps.