### PR TITLE
Update java version and action plugin versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,12 +68,13 @@ jobs:
     #   make bootstrap
     #   make release
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: "temurin"
         java-version: 17
 
     - name: Build with Gradle
       run: ./gradlew build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,10 +67,10 @@ jobs:
     #- run: |
     #   make bootstrap
     #   make release
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
 
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Java SDK
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,12 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java SDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2
         with:
+          distribution: "temurin"
           java-version: 17
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_hash }}
 

--- a/.github/workflows/master_push_workflow.yml
+++ b/.github/workflows/master_push_workflow.yml
@@ -9,12 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: "temurin"
           java-version: 17
       - name: Build with Gradle
         run: ./gradlew build integrationTest

--- a/.github/workflows/master_push_workflow.yml
+++ b/.github/workflows/master_push_workflow.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Build with Gradle
         run: ./gradlew build integrationTest

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: "temurin"
           java-version: 17
       - name: Build with Gradle
         run: ./gradlew build integrationTest


### PR DESCRIPTION
The upgrade to Jetty 12.x requires use of Java 17. Master build workflow used Java 11 and caused failures in integration tests. Upgrade to Java 17 in workflows. The change affects only integration tests, connector is compatible with Java 11.

Upgrade GitHub action plugin versions to newer and not deprecated ones.