### PR TITLE
chore: update to Kafka API 3.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ publishing {
     }
 }
 
-val kafkaVersion = "2.2.0"
+val kafkaVersion = "3.0.2"
 val slf4jVersion = "2.0.13"
 
 val avroVersion = "1.8.1"
@@ -126,7 +126,6 @@ val confluentPlatformVersion = "4.1.4" // For compatibility tests use version 4.
 val hamcrestVersion = "2.2"
 val jacksonVersion = "2.17.0" // This Jackson is used in the tests.
 val jupiterVersion = "5.10.2"
-val jettyVersion = "12.0.8"
 val servletVersion = "4.0.1"
 val testcontainersVersion = "1.19.7"
 val awaitilityVersion = "4.2.1"
@@ -197,9 +196,6 @@ dependencies {
     integrationTestImplementation("javax.servlet:javax.servlet-api:$servletVersion")
     integrationTestImplementation("org.apache.avro:avro:$avroVersion")
     integrationTestImplementation("org.apache.kafka:connect-runtime:$kafkaVersion")
-    integrationTestImplementation("org.eclipse.jetty:jetty-http:$jettyVersion")
-    integrationTestImplementation("org.eclipse.jetty:jetty-server:$jettyVersion")
-    integrationTestImplementation("org.eclipse.jetty:jetty-util:$jettyVersion")
     integrationTestImplementation("org.junit.jupiter:junit-jupiter:$jupiterVersion")
     integrationTestImplementation("org.testcontainers:junit-jupiter:$testcontainersVersion")
     integrationTestImplementation("org.testcontainers:kafka:$testcontainersVersion") // this is not Kafka version

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/AbstractIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/AbstractIT.java
@@ -141,10 +141,17 @@ public abstract class AbstractIT {
 
     @AfterEach
     final void tearDown() {
-        connectRunner.stop();
-        producer.close();
-        consumer.close();
-
-        connectRunner.awaitStop();
+        if (connectRunner != null) {
+            connectRunner.stop();
+        }
+        if (producer != null) {
+            producer.close();
+        }
+        if (consumer != null) {
+            consumer.close();
+        }
+        if (connectRunner != null) {
+            connectRunner.awaitStop();
+        }
     }
 }

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/SchemaRegistryContainer.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/SchemaRegistryContainer.java
@@ -24,7 +24,7 @@ public final class SchemaRegistryContainer extends GenericContainer<SchemaRegist
     public static final int SCHEMA_REGISTRY_PORT = 8081;
 
     public SchemaRegistryContainer(final KafkaContainer kafka) {
-        this("5.0.4", kafka);
+        this("5.4.3", kafka);
     }
 
     public SchemaRegistryContainer(final String confluentPlatformVersion, final KafkaContainer kafka) {

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -56,6 +56,9 @@ public class JdbcSourceTask extends SourceTask {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcSourceTask.class);
 
+    // Visible for testing
+    public static final int MAX_QUERY_SLEEP_MS = 100;
+
     private Time time;
     private JdbcSourceTaskConfig config;
     private DatabaseDialect dialect;
@@ -304,12 +307,16 @@ public class JdbcSourceTask extends SourceTask {
                 final long nextUpdate = querier.getLastUpdate()
                     + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
                 final long untilNext = nextUpdate - time.milliseconds();
-                final long sleepMs = Math.min(untilNext, 100);
+                final long sleepMs = Math.min(untilNext, MAX_QUERY_SLEEP_MS);
                 if (sleepMs > 0) {
                     log.trace("Waiting {} ms to poll {} next ({} ms total left to wait)",
                         sleepMs, querier.toString(), untilNext);
                     time.sleep(sleepMs);
-                    continue; // Re-check stop flag before continuing
+                    // Return control to the Connect runtime periodically
+                    // See https://kafka.apache.org/37/javadoc/org/apache/kafka/connect/source/SourceTask.html#poll():
+                    // "If no data is currently available, this method should block but return control to the caller
+                    // regularly (by returning null)"
+                    return null;
                 }
             }
 

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -79,9 +79,9 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
         // Subsequent polls have to wait for timeout
         task.poll();
-        assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT);
+        assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceTask.MAX_QUERY_SLEEP_MS);
         task.poll();
-        assertThat(time.milliseconds()).isEqualTo(startTime + 2 * JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT);
+        assertThat(time.milliseconds()).isEqualTo(startTime + 2 * JdbcSourceTask.MAX_QUERY_SLEEP_MS);
 
         task.stop();
     }
@@ -111,8 +111,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
         // Subsequent poll should wait for next timeout
         task.poll();
-        assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT);
-
+        assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceTask.MAX_QUERY_SLEEP_MS);
     }
 
     @Test
@@ -137,13 +136,12 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
         assertThat(records.get(0).sourcePartition()).isEqualTo(SECOND_TABLE_PARTITION);
 
         // Subsequent poll should wait for next timeout
-        records = task.poll();
+        records = pollRecords(task);
         assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT);
         validatePollResultTable(records, 1, SINGLE_TABLE_NAME);
-        records = task.poll();
+        records = pollRecords(task);
         assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT);
         validatePollResultTable(records, 1, SECOND_TABLE_NAME);
-
     }
 
     @Test
@@ -178,7 +176,8 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
         // Subsequent poll should wait for next timeout
         for (int i = 0; i < 2; i++) {
-            final List<SourceRecord> records = task.poll();
+            final List<SourceRecord> records;
+            records = pollRecords(task);
             assertThat(time.milliseconds()).isEqualTo(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT);
             validatePollResultTable(records, 1, SINGLE_TABLE_NAME);
         }

--- a/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -19,9 +19,11 @@ package io.aiven.connect.jdbc.source;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
@@ -127,6 +129,14 @@ public class JdbcSourceTaskTestBase {
 
     protected void initializeTask() {
         task.initialize(taskContext);
+    }
+
+    final List<SourceRecord> pollRecords(final JdbcSourceTask task) throws InterruptedException {
+        List<SourceRecord> records = null;
+        while (records == null) {
+            records = task.poll();
+        }
+        return records;
     }
 
 }

--- a/src/test/java/io/aiven/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -64,7 +64,7 @@ public class TimestampIncrementingCriteriaTest {
     }
 
     protected void assertExtractedOffset(final long expected, final Schema schema, final Struct record) {
-        TimestampIncrementingCriteria criteria = null;
+        final TimestampIncrementingCriteria criteria;
         if (schema.field(INCREMENTING_COLUMN.name()) != null) {
             if (schema.field(TS1_COLUMN.name()) != null) {
                 criteria = criteriaIncTs;


### PR DESCRIPTION
Update to Kafka API 3.0.2 as baseline.
Includes correction in JdbcSourceTask to return control to Connect. The SourceTask#poll is required to return instead of blocking when no data is available.