### PR TITLE
chore: bump integration test container startup timeout

### DIFF
--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/AbstractIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/AbstractIT.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.jdbc;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class AbstractIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractIT.class);
+    protected static final Duration CONTAINER_STARTUP_TIMEOUT = Duration.ofMinutes(5);
     protected static final String TEST_TOPIC_NAME = "test_topic";
     private static final String DEFAULT_KAFKA_TAG = "5.4.3";
     private static final DockerImageName DEFAULT_IMAGE_NAME =
@@ -57,11 +59,13 @@ public abstract class AbstractIT {
     @Container
     protected KafkaContainer kafkaContainer = new KafkaContainer(DEFAULT_IMAGE_NAME)
         .withNetwork(Network.newNetwork())
-        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+        .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT);
 
     @Container
     protected SchemaRegistryContainer schemaRegistryContainer =
-        new SchemaRegistryContainer(kafkaContainer);
+        new SchemaRegistryContainer(kafkaContainer)
+            .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT);
 
     protected ConnectRunner connectRunner;
 

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/AbstractPostgresIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/AbstractPostgresIT.java
@@ -40,7 +40,8 @@ public class AbstractPostgresIT extends AbstractIT {
                     .withTag(DEFAULT_POSTGRES_TAG);
 
     @Container
-    protected final PostgreSQLContainer<?> postgreSqlContainer = new PostgreSQLContainer<>(DEFAULT_POSTGRES_IMAGE_NAME);
+    protected final PostgreSQLContainer<?> postgreSqlContainer = new PostgreSQLContainer<>(DEFAULT_POSTGRES_IMAGE_NAME)
+        .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT);
 
     protected void executeUpdate(final String updateStatement) throws SQLException {
         try (final Connection connection = getDatasource().getConnection();


### PR DESCRIPTION
The integration tests can be pretty flaky on my machine, and increasing the startup timeout for their containers gives me a consistent green run. In case others are running into this, we should 1) centralize the definition of our container startup timeouts (done via the `AbsxtractIT.CONTAINER_STARTUP_TIMEOUT` field) and 2) use a higher timeout (five minutes works well on my machine but I'm open to suggestions).