### PR TITLE
feat: implement KIP-618 source connector API related to exactly-once support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ publishing {
     }
 }
 
-val kafkaVersion = "3.0.2"
+val kafkaVersion = "3.3.2"
 val slf4jVersion = "2.0.13"
 
 val avroVersion = "1.8.1"

--- a/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.ExactlyOnceSupport;
 
 import io.aiven.connect.jdbc.config.JdbcConfig;
 import io.aiven.connect.jdbc.source.EmbeddedDerby;
@@ -43,6 +44,7 @@ import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -210,6 +212,30 @@ public class JdbcSourceConnectorTest {
         connector = new JdbcSourceConnector();
         connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
         assertThatThrownBy(() -> connector.start(connProps)).isInstanceOf(ConnectException.class);
+    }
+
+    @Test
+    public void testExactlyOnceSupport() {
+        connProps.remove(JdbcSourceConnectorConfig.MODE_CONFIG);
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(connProps));
+
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, null);
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(connProps));
+
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, "unsupported mode");
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(connProps));
+
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(connProps));
+
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_TIMESTAMP);
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(connProps));
+
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
+        assertEquals(ExactlyOnceSupport.SUPPORTED, connector.exactlyOnceSupport(connProps));
+
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+        assertEquals(ExactlyOnceSupport.SUPPORTED, connector.exactlyOnceSupport(connProps));
     }
 
     private void assertTaskConfigsHaveParentConfigs(final List<Map<String, String>> configs) {


### PR DESCRIPTION
Implements and adds some basic unit testing for the `SourceConnector::exactlyOnceSupport` method, which is invoked by the Kafka Connect runtime when a source connector config has `exactly.once.support` set to `required` in order to allow the connector to communicate whether or not it supports exactly-once semantics with the given configuration.

This API was introduced in Kafka version 3.3, so the Kafka version is bumped to 3.3.2 in our build file.

See [KIP-618](https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors#KIP618:ExactlyOnceSupportforSourceConnectors-ConnectorAPIexpansions) and the [SourceConnector::exactlyOnceSupport Javadocs](https://kafka.apache.org/33/javadoc/org/apache/kafka/connect/source/SourceConnector.html#exactlyOnceSupport(java.util.Map)).