### PR TITLE
feat: Add Validation for PK Mode Against PK Fields and Unit Tests

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/aiven/connect/jdbc/JdbcSinkConnector.java
@@ -68,10 +68,10 @@ public final class JdbcSinkConnector extends SinkConnector {
 
     @Override
     public Config validate(final Map<String, String> connectorConfigs) {
-        // TODO cross-fields validation here: pkFields against the pkMode
         final Config config = super.validate(connectorConfigs);
 
         JdbcSinkConfig.validateDeleteEnabled(config);
+        JdbcSinkConfig.validatePKModeAgainstPKFields(config);
         return config;
     }
 


### PR DESCRIPTION
This PR introduces validation logic for the primary key mode (`pk.mode`) against the primary key fields (`pk.fields`) in the `JdbcSinkConfig` class, ensuring that the configurations adhere to the documented requirements. Additionally, unit tests have been added to verify the correctness of the validation logic.

Changes:

- Implemented `validatePKModeAgainstPKFields` method to validate the primary key mode against the primary key fields.
- Added checks for various combinations of `pk.mode` and `pk.fields` to ensure configurations are valid according to the documentation.