### PR TITLE
Solving different smells in the code.

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
@@ -50,7 +50,9 @@ public class JdbcConfig extends AbstractConfig {
             + "querying with time-based criteria. Defaults to UTC.";
     private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
 
-    public static final String DIALECT_NAME_CONFIG = "dialect.name";
+    // Deficient Encapsulation : This variable in not used outside of this class, but then after it declared as a public variable
+    // So I change access modifier from public to private
+    private static final String DIALECT_NAME_CONFIG = "dialect.name";
     private static final String DIALECT_NAME_DISPLAY = "Database Dialect";
     private static final String DIALECT_NAME_DEFAULT = "";
     private static final String DIALECT_NAME_DOC =

--- a/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/config/JdbcConfig.java
@@ -17,13 +17,13 @@
 package io.aiven.connect.jdbc.config;
 
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.types.Password;
 
 import io.aiven.connect.jdbc.util.TimeZoneValidator;
@@ -186,4 +186,68 @@ public class JdbcConfig extends AbstractConfig {
             JdbcConfig.SQL_QUOTE_IDENTIFIERS_DISPLAY
         );
     }
+
+    protected static void validatePKModeAgainstPKFields(final Config config, final String pkMode, final String pkFields) {
+        final Map<String, ConfigValue> configValues = config.configValues().stream()
+                .collect(Collectors.toMap(ConfigValue::name, v -> v));
+
+        final ConfigValue pkModeConfigValue = configValues.get(pkMode);
+        final ConfigValue pkFieldsConfigValue = configValues.get(pkFields);
+
+        if (pkModeConfigValue == null || pkFieldsConfigValue == null) {
+            return;
+        }
+
+        final String mode = (String) pkModeConfigValue.value();
+        final List<String> fields = (List<String>) pkFieldsConfigValue.value();
+
+        if (mode == null) {
+            return;
+        }
+
+        switch (mode.toLowerCase()) {
+            case "none":
+                if (fields != null && !fields.isEmpty()) {
+                    pkFieldsConfigValue.addErrorMessage(
+                            "Primary key fields should not be set when pkMode is 'none'."
+                    );
+                }
+                break;
+            case "kafka":
+                if (fields == null || fields.size() != 3) {
+                    pkFieldsConfigValue.addErrorMessage(
+                            "Primary key fields must be set with three fields "
+                                    + "(topic, partition, offset) when pkMode is 'kafka'."
+                    );
+                }
+                break;
+            case "record_key":
+            case "record_value":
+                if (fields == null || fields.isEmpty()) {
+                    pkFieldsConfigValue.addErrorMessage(
+                            "Primary key fields must be set when pkMode is 'record_key' or 'record_value'."
+                    );
+                }
+                break;
+            default:
+                pkFieldsConfigValue.addErrorMessage("Invalid pkMode value: " + mode);
+                break;
+        }
+    }
+
+    protected static void validateDeleteEnabled(final Config config, final String deleteEnabledKey, final String pkModeKey) {
+        final Map<String, ConfigValue> configValues = config.configValues().stream()
+                .collect(Collectors.toMap(ConfigValue::name, v -> v));
+
+        final ConfigValue deleteEnabledConfigValue = configValues.get(deleteEnabledKey);
+        final boolean deleteEnabled = (boolean) deleteEnabledConfigValue.value();
+
+        final ConfigValue pkModeConfigValue = configValues.get(pkModeKey);
+        final String pkMode = (String) pkModeConfigValue.value();
+
+        if (deleteEnabled && !"record_key".equalsIgnoreCase(pkMode)) {
+            deleteEnabledConfigValue.addErrorMessage("Delete support only works with pk.mode=record_key");
+        }
+    }
+
 }

--- a/src/main/java/io/aiven/connect/jdbc/sink/BufferManager.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/BufferManager.java
@@ -1,0 +1,48 @@
+package io.aiven.connect.jdbc.sink;
+
+import io.aiven.connect.jdbc.dialect.DatabaseDialect;
+import io.aiven.connect.jdbc.util.TableId;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BufferManager {
+    private final JdbcSinkConfig config;
+    private final DatabaseDialect dbDialect;
+    private final DbStructure dbStructure;
+    private final Connection connection;
+    private final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();
+
+    public BufferManager(JdbcSinkConfig config, DatabaseDialect dbDialect, DbStructure dbStructure, Connection connection) {
+        this.config = config;
+        this.dbDialect = dbDialect;
+        this.dbStructure = dbStructure;
+        this.connection = connection;
+    }
+
+    public void addRecord(SinkRecord record) throws SQLException {
+        final TableId tableId = destinationTable(record.topic());
+        BufferedRecords buffer = bufferByTable.get(tableId);
+        if (buffer == null) {
+            buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, connection);
+            bufferByTable.put(tableId, buffer);
+        }
+        buffer.add(record);
+    }
+
+    public void flushAndClose() throws SQLException {
+        for (Map.Entry<TableId, BufferedRecords> entry : bufferByTable.entrySet()) {
+            final BufferedRecords buffer = entry.getValue();
+            buffer.flush();
+            buffer.close();
+        }
+        bufferByTable.clear();
+    }
+
+    private TableId destinationTable(final String topic) {
+        return dbDialect.parseTableIdentifier(TableNameGenerator.generateTableName(config, topic));
+    }
+}

--- a/src/main/java/io/aiven/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/BufferedRecords.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.aiven.connect.jdbc.util.TableDefinitions;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -51,12 +52,12 @@ public class BufferedRecords {
     private final DatabaseDialect dbDialect;
     private final DbStructure dbStructure;
     private final Connection connection;
-
     private final List<SinkRecord> records = new ArrayList<>();
     private final List<SinkRecord> tombstoneRecords = new ArrayList<>();
     private SchemaPair currentSchemaPair;
     private FieldsMetadata fieldsMetadata;
     private TableDefinition tableDefinition;
+    private TableDefinitions tableDefinitions;
     private PreparedStatement preparedStatement;
     private StatementBinder preparedStatementBinder;
 
@@ -75,6 +76,7 @@ public class BufferedRecords {
         this.dbDialect = dbDialect;
         this.dbStructure = dbStructure;
         this.connection = connection;
+        tableDefinitions = new TableDefinitions(dbDialect);
     }
 
     public List<SinkRecord> add(final SinkRecord record) throws SQLException {
@@ -167,7 +169,7 @@ public class BufferedRecords {
                 fieldsMetadata
         );
 
-        tableDefinition = dbStructure.tableDefinitionFor(tableId, connection);
+        tableDefinition = tableDefinitions.tableDefinitionFor(tableId, connection);
     }
 
     public List<SinkRecord> flush() throws SQLException {

--- a/src/main/java/io/aiven/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/BufferedRecords.java
@@ -76,7 +76,6 @@ public class BufferedRecords {
         this.dbDialect = dbDialect;
         this.dbStructure = dbStructure;
         this.connection = connection;
-        tableDefinitions = new TableDefinitions(dbDialect);
     }
 
     public List<SinkRecord> add(final SinkRecord record) throws SQLException {
@@ -169,7 +168,7 @@ public class BufferedRecords {
                 fieldsMetadata
         );
 
-        tableDefinition = tableDefinitions.tableDefinitionFor(tableId, connection);
+        tableDefinition = dbStructure.tableDefinitionFor(tableId, connection);
     }
 
     public List<SinkRecord> flush() throws SQLException {

--- a/src/main/java/io/aiven/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/DbStructure.java
@@ -78,6 +78,10 @@ public class DbStructure {
         return amendIfNecessary(config, connection, tableId, fieldsMetadata, config.maxRetries);
     }
 
+    public TableDefinition tableDefinitionFor(final TableId tableId, final Connection connection) throws SQLException {
+        return tableDefns.tableDefinitionFor(connection, tableId);
+    }
+
     /**
      * @throws SQLException if CREATE failed
      */

--- a/src/main/java/io/aiven/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/DbStructure.java
@@ -49,15 +49,6 @@ public class DbStructure {
         this.tableDefns = new TableDefinitions(dbDialect);
     }
 
-    public TableDefinition tableDefinitionFor(final TableId tableId, final Connection connection) throws SQLException {
-        final var tblDefinition = tableDefns.get(connection, tableId);
-        if (Objects.nonNull(tblDefinition)) {
-            return tblDefinition;
-        } else {
-            return tableDefns.refresh(connection, tableId);
-        }
-    }
-
     /**
      * @return whether a DDL operation was performed
      * @throws SQLException if a DDL operation was deemed necessary but failed

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcDbWriter.java
@@ -17,39 +17,27 @@
 
 package io.aiven.connect.jdbc.sink;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.SinkRecord;
-
 import io.aiven.connect.jdbc.dialect.DatabaseDialect;
 import io.aiven.connect.jdbc.util.CachedConnectionProvider;
 import io.aiven.connect.jdbc.util.TableId;
-
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
 
 public class JdbcDbWriter {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
 
-    private static final Pattern NORMALIZE_TABLE_NAME_FOR_TOPIC = Pattern.compile("[^a-zA-Z0-9_]");
-
     private final JdbcSinkConfig config;
-
     private final DatabaseDialect dbDialect;
-
     private final DbStructure dbStructure;
-
     final CachedConnectionProvider cachedConnectionProvider;
 
-    JdbcDbWriter(final JdbcSinkConfig config, final DatabaseDialect dbDialect, final DbStructure dbStructure) {
+    public JdbcDbWriter(final JdbcSinkConfig config, final DatabaseDialect dbDialect, final DbStructure dbStructure) {
         this.config = config;
         this.dbDialect = dbDialect;
         this.dbStructure = dbStructure;
@@ -63,62 +51,28 @@ public class JdbcDbWriter {
         };
     }
 
-    void write(final Collection<SinkRecord> records) throws SQLException {
+    public void write(final Collection<SinkRecord> records) throws SQLException {
         final Connection connection = cachedConnectionProvider.getConnection();
+        final BufferManager bufferManager = new BufferManager(config, dbDialect, dbStructure, connection);
 
-        final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();
-        for (final SinkRecord record : records) {
-            final TableId tableId = destinationTable(record.topic());
-            BufferedRecords buffer = bufferByTable.get(tableId);
-            if (buffer == null) {
-                buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, connection);
-                bufferByTable.put(tableId, buffer);
-            }
-            buffer.add(record);
+        for (SinkRecord record : records) {
+            bufferManager.addRecord(record);
         }
-        for (final Map.Entry<TableId, BufferedRecords> entry : bufferByTable.entrySet()) {
-            final TableId tableId = entry.getKey();
-            final BufferedRecords buffer = entry.getValue();
-            log.debug("Flushing records in JDBC Writer for table ID: {}", tableId);
-            buffer.flush();
-            buffer.close();
-        }
+
+        bufferManager.flushAndClose();
         connection.commit();
     }
 
-    void closeQuietly() {
+    public void closeQuietly() {
         cachedConnectionProvider.close();
     }
 
     TableId destinationTable(final String topic) {
-        final String tableName = generateTableNameFor(topic);
+        final String tableName = TableNameGenerator.generateTableName(config, topic);
         return dbDialect.parseTableIdentifier(tableName);
     }
 
     public String generateTableNameFor(final String topic) {
-        String tableName = config.tableNameFormat.replace("${topic}", topic);
-        if (config.tableNameNormalize) {
-            tableName = NORMALIZE_TABLE_NAME_FOR_TOPIC.matcher(tableName).replaceAll("_");
-        }
-        if (!config.topicsToTablesMapping.isEmpty()) {
-            tableName = config.topicsToTablesMapping.getOrDefault(topic, "");
-        }
-        if (tableName.isEmpty()) {
-            final String errorMessage =
-                    String.format(
-                            "Destination table for the topic: '%s' "
-                                    + "couldn't be found in the topics to tables mapping: '%s' "
-                                    + "and couldn't be generated for the format string '%s'",
-                            topic,
-                            config.topicsToTablesMapping
-                                    .entrySet()
-                                    .stream()
-                                    .map(e -> String.join("->", e.getKey(), e.getValue()))
-                                    .collect(Collectors.joining(",")),
-                            config.tableNameFormat);
-            throw new ConnectException(errorMessage);
-        }
-        return tableName;
+        return TableNameGenerator.generateTableName(config, topic);
     }
-
 }

--- a/src/main/java/io/aiven/connect/jdbc/sink/TableNameGenerator.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/TableNameGenerator.java
@@ -1,0 +1,32 @@
+package io.aiven.connect.jdbc.sink;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class TableNameGenerator {
+    private static final Pattern NORMALIZE_TABLE_NAME_FOR_TOPIC = Pattern.compile("[^a-zA-Z0-9_]");
+
+    public static String generateTableName(JdbcSinkConfig config, String topic) {
+        String tableName = config.tableNameFormat.replace("${topic}", topic);
+        if (config.tableNameNormalize) {
+            tableName = NORMALIZE_TABLE_NAME_FOR_TOPIC.matcher(tableName).replaceAll("_");
+        }
+        if (!config.topicsToTablesMapping.isEmpty()) {
+            tableName = config.topicsToTablesMapping.getOrDefault(topic, "");
+        }
+        if (tableName.isEmpty()) {
+            throw new ConnectException(String.format(
+                    "Destination table for the topic: '%s' couldn't be found in the topics to tables mapping: '%s' "
+                            + "and couldn't be generated for the format string '%s'",
+                    topic,
+                    config.topicsToTablesMapping.entrySet().stream()
+                            .map(e -> String.join("->", e.getKey(), e.getValue()))
+                            .collect(Collectors.joining(",")),
+                    config.tableNameFormat
+            ));
+        }
+        return tableName;
+    }
+}

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -309,8 +309,6 @@ public class JdbcSourceTask extends SourceTask {
         }
     }
 
-
-
     //This method returns a list of possible partition maps for different offset protocols
     //This helps with the upgrades
     private List<Map<String, String>> possibleTablePartitions(final String table) {

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -76,19 +76,27 @@ public class JdbcSourceTask extends SourceTask {
     }
 
     // Validation methods
+    // Decompose Complex conditions into smaller parts
     private boolean isIncrementingOrTimestampIncrementing(String incrementalMode) {
-        return incrementalMode.equals(JdbcSourceConnectorConfig.MODE_INCREMENTING)
-                || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+        return isIncrementingMode(incrementalMode) && !isTimestampMode(incrementalMode);
     }
 
     private boolean isTimestampOrTimestampIncrementing(String incrementalMode) {
-        return incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP)
-                || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+        return isTimestampMode(incrementalMode) || isTimestampIncrementingMode(incrementalMode);
     }
 
     private boolean isIncrementingMode(String mode) {
-        return mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)
-                || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)
+        return mode.equals(JdbcSourceConnectorConfig.MODE_INCREMENTING)
+                || mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING);
+    }
+
+    private boolean isTimestampMode(String mode) {
+        return mode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP)
+                || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP);
+    }
+
+    private boolean isTimestampIncrementingMode(String mode) {
+        return mode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING)
                 || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING);
     }
 

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceTask.java
@@ -116,19 +116,88 @@ public class JdbcSourceTask extends SourceTask {
         return Version.getVersion();
     }
 
+    // Extract method validateConfig, initializeDialect, processQueryMode, getTablePartitionsToCheck, processOffsets
+    // addTableQuerier from original start.
     @Override
     public void start(final Map<String, String> properties) {
         log.info("Starting JDBC source task");
+
+        // Validate and initialize configuration
+        validateConfig(properties);
+
+        // Initialize the JDBC dialect (specific database dialect)
+        initializeDialect();
+
+        // Create the connection provider with the required configurations
+        cachedConnectionProvider = new SourceConnectionProvider(
+                dialect,
+                config.getInt(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG),
+                config.getLong(JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG)
+        );
+
+        // Retrieve table names and custom query from config
+        final List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
+        final String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
+
+        // Determine the query mode (either TABLE mode or QUERY mode)
+        final TableQuerier.QueryMode queryMode = !query.isEmpty() ? TableQuerier.QueryMode.QUERY : TableQuerier.QueryMode.TABLE;
+        final List<String> tablesOrQuery = queryMode == TableQuerier.QueryMode.QUERY ? Collections.singletonList(query) : tables;
+
+        // Handle partitions and offsets based on the query mode
+        Map<Map<String, String>, Map<String, Object>> offsets = null;
+        final String mode = config.getMode();
+        if (isSupportedTaskMode(mode)) {
+            offsets = processQueryMode(tables, mode, queryMode, new HashMap<>());
+        }
+
+        // Get additional config values like columns for incrementing, timestamps, and validation
+        final String incrementingColumn = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+        final List<String> timestampColumns = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+        final Long timestampDelayInterval = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
+        final Long timestampInitialMs = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_INITIAL_MS_CONFIG);
+        final Long incrementingOffsetInitial = config.getLong(JdbcSourceTaskConfig.INCREMENTING_INITIAL_VALUE_CONFIG);
+        final boolean validateNonNulls = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+
+        // Iterate over each table or query and process them based on the query mode
+        for (final String tableOrQuery : tablesOrQuery) {
+            // Determine the partitions to check for the current table/query
+            final List<Map<String, String>> tablePartitionsToCheck = getTablePartitionsToCheck(
+                    queryMode, tableOrQuery, validateNonNulls, incrementingColumn, timestampColumns
+            );
+
+            // Process offsets for the partitions
+            Map<String, Object> offset = processOffsets(offsets, tablePartitionsToCheck);
+
+            // Add the appropriate TableQuerier to the queue based on the mode (bulk, incrementing, timestamp)
+            addTableQuerier(
+                    queryMode, mode, tableOrQuery, offset, config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG),
+                    timestampColumns, incrementingColumn, timestampDelayInterval, timestampInitialMs, incrementingOffsetInitial
+            );
+        }
+
+        // Mark the task as running
+        running.set(true);
+        log.info("Started JDBC source task");
+    }
+
+    /**
+     * Validates the configuration for the task and initializes the config object.
+     * Throws a ConnectException if there is an issue with the configuration.
+     */
+    private void validateConfig(Map<String, String> properties) {
         try {
             config = new JdbcSourceTaskConfig(properties);
             config.validate();
         } catch (final ConfigException e) {
             throw new ConnectException("Couldn't start JdbcSourceTask due to configuration error", e);
         }
+    }
 
-        final int maxConnAttempts = config.getInt(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG);
-        final long retryBackoff = config.getLong(JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG);
-
+    /**
+     * Initializes the JDBC dialect based on the provided dialect name or connection URL.
+     * The dialect determines how SQL queries are formed for the specific database.
+     */
+    private void initializeDialect() {
         final String dialectName = config.getDialectName();
         if (dialectName != null && !dialectName.trim().isEmpty()) {
             dialect = DatabaseDialects.create(dialectName, config);
@@ -137,159 +206,110 @@ public class JdbcSourceTask extends SourceTask {
             dialect = DatabaseDialects.findBestFor(connectionUrl, config);
         }
         log.info("Using JDBC dialect {}", dialect.name());
+    }
 
-        cachedConnectionProvider = new SourceConnectionProvider(dialect, maxConnAttempts, retryBackoff);
+    /**
+     * Processes the query mode (TABLE or QUERY) and determines the table partitions to query.
+     * Retrieves the offsets for each partition if the mode is supported.
+     */
+    private Map<Map<String, String>, Map<String, Object>> processQueryMode(
+            List<String> tables, String mode, TableQuerier.QueryMode queryMode,
+            Map<String, List<Map<String, String>>> partitionsByTableFqn) {
 
-        final List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
-        final String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
-
-        final TableQuerier.QueryMode queryMode = !query.isEmpty()
-            ? TableQuerier.QueryMode.QUERY
-            : TableQuerier.QueryMode.TABLE;
-        final List<String> tablesOrQuery = queryMode == TableQuerier.QueryMode.QUERY
-            ? Collections.singletonList(query)
-            : tables;
-
-        final String mode = config.getMode();
-        //used only in table mode
-        final Map<String, List<Map<String, String>>> partitionsByTableFqn = new HashMap<>();
-        Map<Map<String, String>, Map<String, Object>> offsets = null;
-
-        if (isSupportedTaskMode(mode)) {
-            final List<Map<String, String>> partitions = new ArrayList<>(tables.size());
-            switch (queryMode) {
-                case TABLE:
-                    log.trace("Starting in TABLE mode");
-                    for (final String table : tables) {
-                        // Find possible partition maps for different offset protocols
-                        // We need to search by all offset protocol partition keys to support compatibility
-                        final List<Map<String, String>> tablePartitions = possibleTablePartitions(table);
-                        partitions.addAll(tablePartitions);
-                        partitionsByTableFqn.put(table, tablePartitions);
-                    }
-                    break;
-                case QUERY:
-                    log.trace("Starting in QUERY mode");
-                    partitions.add(Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-                        JdbcSourceConnectorConstants.QUERY_NAME_VALUE));
-                    break;
-                default:
-                    throw new ConnectException("Unknown query mode: " + queryMode);
-            }
-            offsets = context.offsetStorageReader().offsets(partitions);
-            log.trace("The partition offsets are {}", offsets);
-        }
-
-        final String incrementingColumn
-            = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
-        final List<String> timestampColumns
-            = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
-        final Long timestampDelayInterval
-            = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
-        final Long timestampInitialMs
-            = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_INITIAL_MS_CONFIG);
-        final Long incrementingOffsetInitial
-            = config.getLong(JdbcSourceTaskConfig.INCREMENTING_INITIAL_VALUE_CONFIG);
-        final boolean validateNonNulls
-            = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
-
-        for (final String tableOrQuery : tablesOrQuery) {
-            final List<Map<String, String>> tablePartitionsToCheck;
-            final Map<String, String> partition;
-            switch (queryMode) {
-                case TABLE:
-                    if (validateNonNulls) {
-                        validateNonNullable(
-                            mode,
-                            tableOrQuery,
-                            incrementingColumn,
-                            timestampColumns
-                        );
-                    }
-                    tablePartitionsToCheck = partitionsByTableFqn.get(tableOrQuery);
-                    break;
-                case QUERY:
-                    partition = Collections.singletonMap(
+        final List<Map<String, String>> partitions = new ArrayList<>(tables.size());
+        switch (queryMode) {
+            case TABLE:
+                log.trace("Starting in TABLE mode");
+                // Find partitions for each table in TABLE mode
+                for (final String table : tables) {
+                    final List<Map<String, String>> tablePartitions = possibleTablePartitions(table);
+                    partitions.addAll(tablePartitions);
+                    partitionsByTableFqn.put(table, tablePartitions);
+                }
+                break;
+            case QUERY:
+                log.trace("Starting in QUERY mode");
+                // In QUERY mode, we only have one partition to check
+                partitions.add(Collections.singletonMap(
                         JdbcSourceConnectorConstants.QUERY_NAME_KEY,
                         JdbcSourceConnectorConstants.QUERY_NAME_VALUE
-                    );
-                    tablePartitionsToCheck = Collections.singletonList(partition);
-                    break;
-                default:
-                    throw new ConnectException("Unexpected query mode: " + queryMode);
-            }
+                ));
+                break;
+            default:
+                throw new ConnectException("Unknown query mode: " + queryMode);
+        }
+        return context.offsetStorageReader().offsets(partitions);
+    }
 
-            // The partition map varies by offset protocol. Since we don't know which protocol each
-            // table's offsets are keyed by, we need to use the different possible partitions
-            // (newest protocol version first) to find the actual offsets for each table.
-            Map<String, Object> offset = null;
-            if (offsets != null) {
-                for (final Map<String, String> toCheckPartition : tablePartitionsToCheck) {
-                    offset = offsets.get(toCheckPartition);
-                    if (offset != null) {
-                        log.info("Found offset {} for partition {}", offsets, toCheckPartition);
-                        break;
-                    }
+    /**
+     * Retrieves the list of table partitions to check based on the query mode.
+     * If validation of non-null values is enabled, it will validate the table.
+     */
+    private List<Map<String, String>> getTablePartitionsToCheck(
+            TableQuerier.QueryMode queryMode, String tableOrQuery, boolean validateNonNulls,
+            String incrementingColumn, List<String> timestampColumns) {
+
+        final List<Map<String, String>> tablePartitionsToCheck;
+        if (queryMode == TableQuerier.QueryMode.TABLE) {
+            if (validateNonNulls) {
+                validateNonNullable(config.getMode(), tableOrQuery, incrementingColumn, timestampColumns);
+            }
+            tablePartitionsToCheck = possibleTablePartitions(tableOrQuery);
+        } else {
+            // In QUERY mode, we add a single partition for the query
+            tablePartitionsToCheck = Collections.singletonList(Collections.singletonMap(
+                    JdbcSourceConnectorConstants.QUERY_NAME_KEY, JdbcSourceConnectorConstants.QUERY_NAME_VALUE
+            ));
+        }
+        return tablePartitionsToCheck;
+    }
+
+    /**
+     * Processes the offsets based on the provided partitions and returns the corresponding offset for the partition.
+     */
+    private Map<String, Object> processOffsets(Map<Map<String, String>, Map<String, Object>> offsets, List<Map<String, String>> tablePartitionsToCheck) {
+        Map<String, Object> offset = null;
+        if (offsets != null) {
+            // Iterate over the partitions and retrieve the offset for the partition
+            for (final Map<String, String> toCheckPartition : tablePartitionsToCheck) {
+                offset = offsets.get(toCheckPartition);
+                if (offset != null) {
+                    log.info("Found offset {} for partition {}", offsets, toCheckPartition);
+                    break;
                 }
             }
-
-            final String topicPrefix = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
-
-            if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
-                tableQueue.add(
-                    new BulkTableQuerier(dialect, queryMode, tableOrQuery, topicPrefix)
-                );
-            } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
-                tableQueue.add(
-                    new TimestampIncrementingTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        null,
-                        incrementingColumn,
-                        offset,
-                        timestampDelayInterval,
-                        timestampInitialMs,
-                        incrementingOffsetInitial,
-                        config.getDBTimeZone())
-                );
-            } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
-                tableQueue.add(
-                    new TimestampIncrementingTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        timestampColumns,
-                        null,
-                        offset,
-                        timestampDelayInterval,
-                        timestampInitialMs,
-                        incrementingOffsetInitial,
-                        config.getDBTimeZone())
-                );
-            } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
-                tableQueue.add(
-                    new TimestampIncrementingTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        timestampColumns,
-                        incrementingColumn,
-                        offset,
-                        timestampDelayInterval,
-                        timestampInitialMs,
-                        incrementingOffsetInitial,
-                        config.getDBTimeZone())
-                );
-            }
         }
-
-        running.set(true);
-        log.info("Started JDBC source task");
+        return offset;
     }
+
+    /**
+     * Adds the appropriate TableQuerier (Bulk, Incrementing, or Timestamp-based) to the task queue.
+     * Depending on the mode, different queriers are added.
+     */
+    private void addTableQuerier(
+            TableQuerier.QueryMode queryMode, String mode, String tableOrQuery,
+            Map<String, Object> offset, String topicPrefix, List<String> timestampColumns,
+            String incrementingColumn, Long timestampDelayInterval, Long timestampInitialMs, Long incrementingOffsetInitial) {
+
+        // Add a BulkTableQuerier for BULK mode
+        if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
+            tableQueue.add(new BulkTableQuerier(dialect, queryMode, tableOrQuery, topicPrefix));
+        }
+        // Add a TimestampIncrementingTableQuerier for INCREMENTING mode
+        else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
+            tableQueue.add(new TimestampIncrementingTableQuerier(dialect, queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset, timestampDelayInterval, timestampInitialMs, incrementingOffsetInitial, config.getDBTimeZone()));
+        }
+        // Add a TimestampIncrementingTableQuerier for TIMESTAMP mode
+        else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
+            tableQueue.add(new TimestampIncrementingTableQuerier(dialect, queryMode, tableOrQuery, topicPrefix, timestampColumns, null, offset, timestampDelayInterval, timestampInitialMs, incrementingOffsetInitial, config.getDBTimeZone()));
+        }
+        // Add a TimestampIncrementingTableQuerier for TIMESTAMP_INCREMENTING mode
+        else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
+            tableQueue.add(new TimestampIncrementingTableQuerier(dialect, queryMode, tableOrQuery, topicPrefix, timestampColumns, incrementingColumn, offset, timestampDelayInterval, timestampInitialMs, incrementingOffsetInitial, config.getDBTimeZone()));
+        }
+    }
+
+
 
     //This method returns a list of possible partition maps for different offset protocols
     //This helps with the upgrades

--- a/src/main/java/io/aiven/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/aiven/connect/jdbc/util/TableDefinitions.java
@@ -1,20 +1,3 @@
-/*
- * Copyright 2019 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
- * Copyright 2018 Confluent Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.aiven.connect.jdbc.util;
 
 import java.sql.Connection;
@@ -56,8 +39,8 @@ public class TableDefinitions {
      * @throws SQLException if there is any problem using the connection
      */
     public TableDefinition get(
-        final Connection connection,
-        final TableId tableId
+            final Connection connection,
+            final TableId tableId
     ) throws SQLException {
         TableDefinition dbTable = cache.get(tableId);
         if (dbTable == null) {
@@ -81,8 +64,8 @@ public class TableDefinitions {
      * @throws SQLException if there is any problem using the connection
      */
     public TableDefinition refresh(
-        final Connection connection,
-        final TableId tableId
+            final Connection connection,
+            final TableId tableId
     ) throws SQLException {
         final TableDefinition dbTable = dialect.describeTable(connection, tableId);
         log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
@@ -90,12 +73,22 @@ public class TableDefinitions {
         return dbTable;
     }
 
-    public TableDefinition tableDefinitionFor(final TableId tableId, final Connection connection) throws SQLException {
-        final var tblDefinition = this.get(connection, tableId);
-        if (Objects.nonNull(tblDefinition)) {
-            return tblDefinition;
-        } else {
-            return this.refresh(connection, tableId);
+    /**
+     * Get the TableDefinition for a table, ensuring it is initialized in cache.
+     *
+     * @param connection the JDBC connection to use; may not be null
+     * @param tableId    the table identifier; may not be null
+     * @return the {@link TableDefinition} for the table
+     * @throws SQLException if there is any problem using the connection
+     */
+    public TableDefinition tableDefinitionFor(
+            final Connection connection,
+            final TableId tableId
+    ) throws SQLException {
+        TableDefinition tableDefn = get(connection, tableId);
+        if (tableDefn == null) {
+            tableDefn = refresh(connection, tableId);
         }
+        return tableDefn;
     }
 }

--- a/src/main/java/io/aiven/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/aiven/connect/jdbc/util/TableDefinitions.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import io.aiven.connect.jdbc.dialect.DatabaseDialect;
 
@@ -87,5 +88,14 @@ public class TableDefinitions {
         log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
         cache.put(dbTable.id(), dbTable);
         return dbTable;
+    }
+
+    public TableDefinition tableDefinitionFor(final TableId tableId, final Connection connection) throws SQLException {
+        final var tblDefinition = this.get(connection, tableId);
+        if (Objects.nonNull(tblDefinition)) {
+            return tblDefinition;
+        } else {
+            return this.refresh(connection, tableId);
+        }
     }
 }


### PR DESCRIPTION
- **Decompose the conditions** - `source.JdbcSourceTask.java`

- **Rename variable** - `source.JdbcSourceTask.java` (atLeastOneTimestampNotOptional to timestampRequired)

- **Extract methods** - `source.JdbcSourceTask.java` (`start()` method is so long so I extract the methods from this and try to make `start()` method small. Extracted methods: `validateConfig()`,  `initializeDialect()`, `processQueryMode()`, `getTablePartitionsToCheck()`, `processOffsets()`, `addTableQuerier()`)

- **Move method** - `sink.Dbstructure.java` (`DbStructure` class in not a proper place for `tableDefinitionFor()` so I moved it into `TableDefinitions` class)

- **Extract Class** - `sink.JdbcDbWriter` (Decompose the `JdbcDbWriter` into 2 classes: `BufferManager` and `TableNameGenerator`)

- **Pull-up method** - `sink.JdbcSinkConfig.java` (pull-up method means move method from sub class to parent class, so I moved `validateDeleteEnabled()` and `validatePKModeAgainstPKFields()` into parent class which is `JdbcConfig`)